### PR TITLE
Use base_link as the robot root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+- Use `base_link` as the robot root across Xacro, URDF, MJCF, and USD assets.
+- Make `base_footprint` a direct fixed child while preserving MJCF and USD
+  physical placement, joint anchors, and controller targets.

--- a/config/mjcf/joint_data_planar_base.json
+++ b/config/mjcf/joint_data_planar_base.json
@@ -1,7 +1,7 @@
 {
   "extra_joints": [
     {
-      "body": "base_footprint",
+      "body": "base_link",
       "joints": [
         {
           "name": "base_x_joint",

--- a/mjcf/galbot_one_golf.xml
+++ b/mjcf/galbot_one_golf.xml
@@ -20,8 +20,8 @@
   </visual>
 
   <worldbody>
-    <body name="base_footprint" childclass="robot" pos="0 0 0.0062">
-      <body name="base_link" pos="0 0 0.028166">
+    <body name="base_link" childclass="robot" pos="0 0 0.034366">
+      <body name="base_footprint" pos="0 0 -0.028166" />
         <body name="omni_chassis_base_link">
           <inertial pos="0.02079 0.00615 0.07261" mass="30.15" diaginertia="0.3317069394 0.32081635568 0.55833152838" />
           <geom name="omni_chassis_base_link_collision" type="mesh" mesh="omni_chassis_base_link_collision_chassis_collision_01" class="collision" />
@@ -658,7 +658,6 @@
             <geom type="mesh" class="visual" name="chassis_lidar_visual_1" mesh="chassis_lidar_mid360_1" material="mtl_meshes_meshes_visual_sensors_mid360_mid360_M_sensors_mid360_blue" />
           </body>
         </body>
-      </body>
       <freejoint name="floating_base" />
     </body>
     <light pos="0 0 2." dir="0 0 -1" directional="true" />

--- a/mjcf/galbot_one_golf_fixed_base.xml
+++ b/mjcf/galbot_one_golf_fixed_base.xml
@@ -20,8 +20,8 @@
   </visual>
 
   <worldbody>
-    <body name="base_footprint" childclass="robot" pos="0 0 0.0062">
-      <body name="base_link" pos="0 0 0.028166">
+    <body name="base_link" childclass="robot" pos="0 0 0.034366">
+      <body name="base_footprint" pos="0 0 -0.028166" />
         <body name="omni_chassis_base_link">
           <inertial pos="0.02079 0.00615 0.07261" mass="30.15" diaginertia="0.3317069394 0.32081635568 0.55833152838" />
           <geom name="omni_chassis_base_link_collision" type="mesh" mesh="omni_chassis_base_link_collision_chassis_collision_01" class="collision" />
@@ -494,7 +494,6 @@
             <geom type="mesh" class="visual" name="chassis_lidar_visual_1" mesh="chassis_lidar_mid360_1" material="mtl_meshes_meshes_visual_sensors_mid360_mid360_M_sensors_mid360_blue" />
           </body>
         </body>
-      </body>
     </body>
     <light pos="0 0 2." dir="0 0 -1" directional="true" />
     <geom name="floor" class="floor" size="0 0 0.05" />

--- a/mjcf/galbot_one_golf_planar_base.xml
+++ b/mjcf/galbot_one_golf_planar_base.xml
@@ -20,12 +20,12 @@
   </visual>
 
   <worldbody>
-    <body name="base_footprint" childclass="robot" pos="0 0 0.0062">
+    <body name="base_link" childclass="robot" pos="0 0 0.034366">
       <inertial pos="0 0 0" mass="0.001" diaginertia="1e-06 1e-06 1e-06" />
       <joint name="base_x_joint" type="slide" axis="1.0 0.0 0.0" armature="0.001" damping="0.0" frictionloss="0.0" />
       <joint name="base_y_joint" type="slide" axis="0.0 1.0 0.0" armature="0.001" damping="0.0" frictionloss="0.0" />
       <joint name="base_yaw_joint" type="hinge" axis="0.0 0.0 1.0" armature="0.001" damping="0.0" frictionloss="0.0" />
-      <body name="base_link" pos="0 0 0.028166">
+      <body name="base_footprint" pos="0 0 -0.028166" />
         <body name="omni_chassis_base_link">
           <inertial pos="0.02079 0.00615 0.07261" mass="30.15" diaginertia="0.3317069394 0.32081635568 0.55833152838" />
           <geom name="omni_chassis_base_link_collision" type="mesh" mesh="omni_chassis_base_link_collision_chassis_collision_01" class="collision" />
@@ -498,7 +498,6 @@
             <geom type="mesh" class="visual" name="chassis_lidar_visual_1" mesh="chassis_lidar_mid360_1" material="mtl_meshes_meshes_visual_sensors_mid360_mid360_M_sensors_mid360_blue" />
           </body>
         </body>
-      </body>
     </body>
     <light pos="0 0 2." dir="0 0 -1" directional="true" />
     <geom name="floor" class="floor" size="0 0 0.05" />

--- a/urdf/galbot_one_golf.urdf
+++ b/urdf/galbot_one_golf.urdf
@@ -177,13 +177,13 @@
     </collision>
   </link>
   <!-- Robot Base Link -->
+  <link name="base_link"/>
   <link name="base_footprint"/>
   <joint name="base_footprint_joint" type="fixed">
-    <origin xyz="0 0 0.028166"/>
-    <parent link="base_footprint"/>
-    <child link="base_link"/>
+    <origin xyz="0 0 -0.028166"/>
+    <parent link="base_link"/>
+    <child link="base_footprint"/>
   </joint>
-  <link name="base_link"/>
   <joint name="omni_chassis_joint" type="fixed">
     <parent link="base_link"/>
     <child link="omni_chassis_base_link"/>

--- a/urdf/galbot_one_golf_fixed_base.urdf
+++ b/urdf/galbot_one_golf_fixed_base.urdf
@@ -177,13 +177,13 @@
     </collision>
   </link>
   <!-- Robot Base Link -->
+  <link name="base_link"/>
   <link name="base_footprint"/>
   <joint name="base_footprint_joint" type="fixed">
-    <origin xyz="0 0 0.028166"/>
-    <parent link="base_footprint"/>
-    <child link="base_link"/>
+    <origin xyz="0 0 -0.028166"/>
+    <parent link="base_link"/>
+    <child link="base_footprint"/>
   </joint>
-  <link name="base_link"/>
   <joint name="omni_chassis_joint" type="fixed">
     <parent link="base_link"/>
     <child link="omni_chassis_base_link"/>

--- a/usd/payloads/Physics/mujoco.usda
+++ b/usd/payloads/Physics/mujoco.usda
@@ -37,21 +37,22 @@ Generated from Composed Stage of root layer /home/galbot/Downloads/galbot_one_go
 
 over "galbot_one_golf"
 {
-    over "base_footprint"
+    over "base_link"
     {
-        over "base_link"
+        over "base_footprint"
         {
-            over "omni_chassis_base_link"
-            {
-                over "chassis_lidar"
-                {
-                }
+        }
 
-                over "omni_chassis_leg_mount_link"
+        over "omni_chassis_base_link"
+        {
+            over "chassis_lidar"
+            {
+            }
+
+            over "omni_chassis_leg_mount_link"
+            {
+                over "leg_base_link"
                 {
-                    over "leg_base_link"
-                    {
-                    }
                 }
             }
         }
@@ -2448,4 +2449,3 @@ over "Render"
         }
     }
 }
-

--- a/usd/payloads/Physics/physics.usda
+++ b/usd/payloads/Physics/physics.usda
@@ -38,11 +38,11 @@ Generated from Composed Stage of root layer /home/galbot/Downloads/galbot_one_go
 
 over "galbot_one_golf"
 {
-    over "base_footprint" (
+    over "base_link" (
         prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI", "PhysicsArticulationRootAPI"]
     )
     {
-        point3f physics:centerOfMass = (0.02643079, 0.0031478503, 0.10375823)
+        point3f physics:centerOfMass = (0.02643079, 0.0031478503, 0.07559223)
         float3 physics:diagonalInertia = (0.35954753, 0.33839372, 0.59155643)
         float physics:mass = 31.73
         quatf physics:principalAxes = (0.93358207, -0.01696257, -0.015557792, 0.35762396)
@@ -73,13 +73,13 @@ over "galbot_one_golf"
             uniform token drive:angular:physics:type = "force"
             uniform token physics:axis = "Z"
             custom rel physics:body0
-            prepend rel physics:body0 = </galbot_one_golf/base_footprint>
+            prepend rel physics:body0 = </galbot_one_golf/base_link>
             custom rel physics:body1
             prepend rel physics:body1 = </galbot_one_golf/leg_link1>
             float physics:breakForce = 3.4028235e38
             float physics:breakTorque = 3.4028235e38
             float physics:JointEquivalentInertia = 3.9542305
-            point3f physics:localPos0 = (0.134, 0, 0.16066599)
+            point3f physics:localPos0 = (0.134, 0, 0.13249999)
             point3f physics:localPos1 = (0, 0, 0)
             quatf physics:localRot0 = (-0.13527897, 0.13527891, 0.6940458, 0.6940458)
             quatf physics:localRot1 = (1, 0, 0, 0)
@@ -916,13 +916,13 @@ over "galbot_one_golf"
             custom double isaacmecanumwheel:radius = 0.1
             uniform token physics:axis = "X"
             custom rel physics:body0
-            prepend rel physics:body0 = </galbot_one_golf/base_footprint>
+            prepend rel physics:body0 = </galbot_one_golf/base_link>
             custom rel physics:body1
             prepend rel physics:body1 = </galbot_one_golf/wheel_1>
             float physics:breakForce = 3.4028235e38
             float physics:breakTorque = 3.4028235e38
             float physics:JointEquivalentInertia = 0.4997348
-            point3f physics:localPos0 = (0.176493, 0.176493, 0.099999994)
+            point3f physics:localPos0 = (0.176493, 0.176493, 0.071833994)
             point3f physics:localPos1 = (0, 0, 0)
             quatf physics:localRot0 = (0.38268343, 0, 0, -0.9238795)
             quatf physics:localRot1 = (1, 0, 0, 0)
@@ -1193,13 +1193,13 @@ over "galbot_one_golf"
             custom double isaacmecanumwheel:radius = 0.1
             uniform token physics:axis = "X"
             custom rel physics:body0
-            prepend rel physics:body0 = </galbot_one_golf/base_footprint>
+            prepend rel physics:body0 = </galbot_one_golf/base_link>
             custom rel physics:body1
             prepend rel physics:body1 = </galbot_one_golf/wheel_2>
             float physics:breakForce = 3.4028235e38
             float physics:breakTorque = 3.4028235e38
             float physics:JointEquivalentInertia = 0.50026107
-            point3f physics:localPos0 = (-0.176493, 0.176493, 0.099999994)
+            point3f physics:localPos0 = (-0.176493, 0.176493, 0.071833994)
             point3f physics:localPos1 = (0, 0, 0)
             quatf physics:localRot0 = (0.9238795, 0, 0, -0.38268346)
             quatf physics:localRot1 = (1, 0, 0, 0)
@@ -1470,13 +1470,13 @@ over "galbot_one_golf"
             custom double isaacmecanumwheel:radius = 0.1
             uniform token physics:axis = "X"
             custom rel physics:body0
-            prepend rel physics:body0 = </galbot_one_golf/base_footprint>
+            prepend rel physics:body0 = </galbot_one_golf/base_link>
             custom rel physics:body1
             prepend rel physics:body1 = </galbot_one_golf/wheel_3>
             float physics:breakForce = 3.4028235e38
             float physics:breakTorque = 3.4028235e38
             float physics:JointEquivalentInertia = 0.50015295
-            point3f physics:localPos0 = (-0.176493, -0.176493, 0.099999994)
+            point3f physics:localPos0 = (-0.176493, -0.176493, 0.071833994)
             point3f physics:localPos1 = (0, 0, 0)
             quatf physics:localRot0 = (0.9238795, 0, 0, 0.38268346)
             quatf physics:localRot1 = (1, 0, 0, 0)
@@ -1747,13 +1747,13 @@ over "galbot_one_golf"
             custom double isaacmecanumwheel:radius = 0.1
             uniform token physics:axis = "X"
             custom rel physics:body0
-            prepend rel physics:body0 = </galbot_one_golf/base_footprint>
+            prepend rel physics:body0 = </galbot_one_golf/base_link>
             custom rel physics:body1
             prepend rel physics:body1 = </galbot_one_golf/wheel_4>
             float physics:breakForce = 3.4028235e38
             float physics:breakTorque = 3.4028235e38
             float physics:JointEquivalentInertia = 0.4995947
-            point3f physics:localPos0 = (0.176493, -0.176493, 0.099999994)
+            point3f physics:localPos0 = (0.176493, -0.176493, 0.071833994)
             point3f physics:localPos1 = (0, 0, 0)
             quatf physics:localRot0 = (0.38268343, 0, 0, 0.9238795)
             quatf physics:localRot1 = (1, 0, 0, 0)

--- a/usd/payloads/Physics/physx.usda
+++ b/usd/payloads/Physics/physx.usda
@@ -36,7 +36,7 @@
 
 def "galbot_one_golf"
 {
-    over "base_footprint" (
+    over "base_link" (
         prepend apiSchemas = ["PhysxArticulationAPI"]
     )
     {
@@ -626,4 +626,3 @@ def "galbot_one_golf"
         }
     }
 }
-

--- a/usd/payloads/Robot/robot.usda
+++ b/usd/payloads/Robot/robot.usda
@@ -117,7 +117,7 @@ def Xform "galbot_one_golf" (
         </galbot_one_golf/joints/wheel_4_passive_9_joint>,
     ]
     prepend rel isaac:physics:robotLinks = [
-        </galbot_one_golf/base_footprint>,
+        </galbot_one_golf/base_link>,
         </galbot_one_golf/leg_link1>,
         </galbot_one_golf/leg_link2>,
         </galbot_one_golf/leg_link3>,
@@ -197,7 +197,7 @@ def Xform "galbot_one_golf" (
         </galbot_one_golf/wheel_4_passive_9>,
     ]
 
-    over "base_footprint" (
+    over "base_link" (
         prepend apiSchemas = ["IsaacLinkAPI"]
     )
     {
@@ -1978,4 +1978,3 @@ def Xform "galbot_one_golf" (
         string isaac:nameOverride
     }
 }
-

--- a/usd/payloads/base.usda
+++ b/usd/payloads/base.usda
@@ -46,49 +46,49 @@ def Xform "galbot_one_golf"
     double3 xformOp:translate = (0, 0, 0)
     uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
 
-    def Xform "base_footprint"
+    def Xform "base_link"
     {
         quatd xformOp:orient = (1, 0, 0, 0)
         double3 xformOp:scale = (1, 1, 1)
-        double3 xformOp:translate = (0, 0, 0)
+        double3 xformOp:translate = (0, 0, 0.028165999799966812)
         uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
 
-        def Xform "base_link"
+        def Xform "base_footprint"
         {
             quatd xformOp:orient = (1, 0, 0, 0)
             double3 xformOp:scale = (1, 1, 1)
-            double3 xformOp:translate = (0, 0, 0.028165999799966812)
+            double3 xformOp:translate = (0, 0, -0.028165999799966812)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
+        }
+
+        def Xform "omni_chassis_base_link"
+        {
+            quatd xformOp:orient = (1, 0, 0, 0)
+            double3 xformOp:scale = (1, 1, 1)
+            double3 xformOp:translate = (0, 0, 0)
             uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
 
-            def Xform "omni_chassis_base_link"
+            def Xform "chassis_lidar"
             {
                 quatd xformOp:orient = (1, 0, 0, 0)
                 double3 xformOp:scale = (1, 1, 1)
-                double3 xformOp:translate = (0, 0, 0)
+                double3 xformOp:translate = (0.23499999940395355, 0, 0.21439999341964722)
+                uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
+            }
+
+            def Xform "omni_chassis_leg_mount_link"
+            {
+                quatd xformOp:orient = (1, 0, 0, 0)
+                double3 xformOp:scale = (1, 1, 1)
+                double3 xformOp:translate = (0.1340000033378601, 0, 0.13249999284744263)
                 uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
 
-                def Xform "chassis_lidar"
+                def Xform "leg_base_link"
                 {
                     quatd xformOp:orient = (1, 0, 0, 0)
                     double3 xformOp:scale = (1, 1, 1)
-                    double3 xformOp:translate = (0.23499999940395355, 0, 0.21439999341964722)
+                    double3 xformOp:translate = (0, 0, 0)
                     uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
-                }
-
-                def Xform "omni_chassis_leg_mount_link"
-                {
-                    quatd xformOp:orient = (1, 0, 0, 0)
-                    double3 xformOp:scale = (1, 1, 1)
-                    double3 xformOp:translate = (0.1340000033378601, 0, 0.13249999284744263)
-                    uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
-
-                    def Xform "leg_base_link"
-                    {
-                        quatd xformOp:orient = (1, 0, 0, 0)
-                        double3 xformOp:scale = (1, 1, 1)
-                        double3 xformOp:translate = (0, 0, 0)
-                        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
-                    }
                 }
             }
         }
@@ -105,7 +105,7 @@ def Xform "galbot_one_golf"
                 token visibility = "inherited"
                 quatd xformOp:orient = (1, 0, 0, 0)
                 double3 xformOp:scale = (1, 1, 1)
-                double3 xformOp:translate = (0, 0, 0.0281659998)
+                double3 xformOp:translate = (0, 0, 0)
                 uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
             }
 
@@ -117,7 +117,7 @@ def Xform "galbot_one_golf"
                 token visibility = "inherited"
                 quatd xformOp:orient = (1, 0, 0, 0)
                 double3 xformOp:scale = (1, 1, 1)
-                double3 xformOp:translate = (0.2349999994, 0, 0.2425659895)
+                double3 xformOp:translate = (0.2349999994, 0, 0.2143999897)
                 uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
             }
         }
@@ -135,7 +135,7 @@ def Xform "galbot_one_golf"
                 token visibility = "inherited"
                 quatd xformOp:orient = (1, 0, 0, 0)
                 double3 xformOp:scale = (1, 1, 1)
-                double3 xformOp:translate = (0, 0, 0.0281659998)
+                double3 xformOp:translate = (0, 0, 0)
                 uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
             }
 
@@ -148,7 +148,7 @@ def Xform "galbot_one_golf"
                 token visibility = "inherited"
                 quatd xformOp:orient = (1, 0, 0, 0)
                 double3 xformOp:scale = (1, 1, 1)
-                double3 xformOp:translate = (0.2349999994, 0, 0.2425659895)
+                double3 xformOp:translate = (0.2349999994, 0, 0.2143999897)
                 uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
             }
 
@@ -161,7 +161,7 @@ def Xform "galbot_one_golf"
                 token visibility = "inherited"
                 quatd xformOp:orient = (1, 0, 0, 0)
                 double3 xformOp:scale = (1, 1, 1)
-                double3 xformOp:translate = (0.2349999994, 0, 0.2425659895)
+                double3 xformOp:translate = (0.2349999994, 0, 0.2143999897)
                 uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
             }
         }
@@ -4102,7 +4102,7 @@ def Xform "galbot_one_golf"
             prepend apiSchemas = ["NodeGraphNodeAPI"]
         )
         {
-            custom rel inputs:comPrim = </galbot_one_golf/base_footprint/base_link> (
+            custom rel inputs:comPrim = </galbot_one_golf/base_link> (
                 customData = {
                     dictionary omni = {
                         dictionary graph = {
@@ -4188,7 +4188,7 @@ def Xform "galbot_one_golf"
             token[] inputs:jointNames.connect = </galbot_one_golf/holonomic_controller/usd_setup_holonomic_robot.outputs:wheelDofNames>
             custom double[] inputs:positionCommand
             custom string inputs:robotPath
-            custom rel inputs:targetPrim = </galbot_one_golf/base_footprint> (
+            custom rel inputs:targetPrim = </galbot_one_golf/base_link> (
                 customData = {
                     dictionary omni = {
                         dictionary graph = {

--- a/usd/payloads/robot.usda
+++ b/usd/payloads/robot.usda
@@ -119,7 +119,7 @@ over "galbot_one_golf" (
         </galbot_one_golf/joints/wheel_4_passive_9_joint>,
     ]
     prepend rel isaac:physics:robotLinks = [
-        </galbot_one_golf/base_footprint>,
+        </galbot_one_golf/base_link>,
         </galbot_one_golf/leg_link1>,
         </galbot_one_golf/leg_link2>,
         </galbot_one_golf/leg_link3>,
@@ -246,7 +246,7 @@ over "galbot_one_golf" (
         </galbot_one_golf/wheel_4_passive_9/visuals>,
     ]
 
-    over "base_footprint" (
+    over "base_link" (
         prepend apiSchemas = ["IsaacLinkAPI"]
     )
     {
@@ -2309,4 +2309,3 @@ over "galbot_one_golf" (
         }
     }
 }
-

--- a/xacro/components/omni_chassis.xacro
+++ b/xacro/components/omni_chassis.xacro
@@ -8,14 +8,14 @@
 
   <xacro:macro name="GalbotChassisV2" params="enable_wheel_joints:='false' enable_passive_wheels:='false'">
     <!-- Robot Base Link -->
+    <link name="base_link"/>
     <link name="base_footprint"/>
     <joint name="base_footprint_joint" type="fixed">
-      <origin xyz="0 0 0.028166"/>
-      <parent link="base_footprint"/>
-      <child link="base_link"/>
+      <origin xyz="0 0 -0.028166"/>
+      <parent link="base_link"/>
+      <child link="base_footprint"/>
     </joint>
 
-    <link name="base_link"/>
     <joint name="omni_chassis_joint" type="fixed">
       <parent link="base_link"/>
       <child link="omni_chassis_base_link"/>


### PR DESCRIPTION
## Summary

- use `base_link` as the root link/body across Xacro, URDF, MJCF, and USD
- make `base_footprint` a direct fixed child with the preserved `-0.028166 m` offset
- migrate USD articulation, rigid-body, Isaac link, COM, joint-anchor, and OmniGraph targets
- update planar-base generation metadata and add a concise changelog entry

## Why

The description formats previously disagreed on whether `base_footprint` or `base_link` was the robot root. This aligns their public hierarchy while preserving MJCF/USD physical world placement and joint anchors.

## Validation

- XML parsing and `check_urdf` for both checked-in URDFs
- all three MJCF models compile and step in MuJoCo
- 12 OpenUSD variant combinations compose with the requested hierarchy
- all 77 USD joint anchors remain aligned
- Isaac Sim 5.1 loads and advances the PhysX/OmniGraph simulation for 30 steps with ROS 2 configured
- `git diff --check`