### PR TITLE
Fix gripper TCP frame orientation

### DIFF
--- a/.github/workflows/validate-description.yml
+++ b/.github/workflows/validate-description.yml
@@ -1,0 +1,16 @@
+name: Validate description
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  tcp-frames:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python3 scripts/validate_tcp_frames.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Correct both gripper TCP frames by removing an unintended 180-degree X-axis
+  flip relative to the original Golf convention, consistently across Xacro,
+  URDF, MJCF, and USD.
 - Use `base_link` as the robot root across Xacro, URDF, MJCF, and USD assets.
 - Make `base_footprint` a direct fixed child while preserving MJCF and USD
   physical placement, joint anchors, and controller targets.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ MJCF base variants:
 | --- |
 | ![Galbot One Golf MJCF visual model](docs/.images/galbot_one_golf_mjcf.png) |
 
+## TCP frame
+
+Both gripper TCP links use the same transform in Xacro, URDF, MJCF, and USD:
+translation `(0.13996, 0, 0)` from the gripper base and rotation `(-pi/2, 0, 0)`
+in roll-pitch-yaw order. Run `python3 scripts/validate_tcp_frames.py` after changing
+any generated description.
+
 ## USD
 
 The main USD entry point is `usd/galbot_one_golf.usda`. Related payloads,

--- a/mjcf/galbot_one_golf.xml
+++ b/mjcf/galbot_one_golf.xml
@@ -227,7 +227,7 @@
                                                         <geom type="mesh" class="visual" name="left_gripper_l_finger_link_visual_2" mesh="left_gripper_l_finger_link_link3_2" material="mtl_meshes_meshes_visual_end_effectors_galbot_gripper_link3_M_end_effectors_galbot_gripper_link3_plastic_black" />
                                                       </body>
                                                     </body>
-                                                    <body name="left_gripper_tcp_link" pos="0.13996 0 0" quat="0.7071 0.7071 0 0" />
+                                                    <body name="left_gripper_tcp_link" pos="0.13996 0 0" quat="0.7071 -0.7071 0 0" />
                                                   </body>
                                                 </body>
                                               </body>
@@ -393,7 +393,7 @@
                                                         <geom type="mesh" class="visual" name="right_gripper_l_finger_link_visual_2" mesh="left_gripper_l_finger_link_link3_2" material="mtl_meshes_meshes_visual_end_effectors_galbot_gripper_link3_M_end_effectors_galbot_gripper_link3_plastic_black" />
                                                       </body>
                                                     </body>
-                                                    <body name="right_gripper_tcp_link" pos="0.13996 0 0" quat="0.7071 0.7071 0 0" />
+                                                    <body name="right_gripper_tcp_link" pos="0.13996 0 0" quat="0.7071 -0.7071 0 0" />
                                                   </body>
                                                 </body>
                                               </body>

--- a/mjcf/galbot_one_golf_fixed_base.xml
+++ b/mjcf/galbot_one_golf_fixed_base.xml
@@ -227,7 +227,7 @@
                                                         <geom type="mesh" class="visual" name="left_gripper_l_finger_link_visual_2" mesh="left_gripper_l_finger_link_link3_2" material="mtl_meshes_meshes_visual_end_effectors_galbot_gripper_link3_M_end_effectors_galbot_gripper_link3_plastic_black" />
                                                       </body>
                                                     </body>
-                                                    <body name="left_gripper_tcp_link" pos="0.13996 0 0" quat="0.7071 0.7071 0 0" />
+                                                    <body name="left_gripper_tcp_link" pos="0.13996 0 0" quat="0.7071 -0.7071 0 0" />
                                                   </body>
                                                 </body>
                                               </body>
@@ -393,7 +393,7 @@
                                                         <geom type="mesh" class="visual" name="right_gripper_l_finger_link_visual_2" mesh="left_gripper_l_finger_link_link3_2" material="mtl_meshes_meshes_visual_end_effectors_galbot_gripper_link3_M_end_effectors_galbot_gripper_link3_plastic_black" />
                                                       </body>
                                                     </body>
-                                                    <body name="right_gripper_tcp_link" pos="0.13996 0 0" quat="0.7071 0.7071 0 0" />
+                                                    <body name="right_gripper_tcp_link" pos="0.13996 0 0" quat="0.7071 -0.7071 0 0" />
                                                   </body>
                                                 </body>
                                               </body>

--- a/mjcf/galbot_one_golf_planar_base.xml
+++ b/mjcf/galbot_one_golf_planar_base.xml
@@ -231,7 +231,7 @@
                                                         <geom type="mesh" class="visual" name="left_gripper_l_finger_link_visual_2" mesh="left_gripper_l_finger_link_link3_2" material="mtl_meshes_meshes_visual_end_effectors_galbot_gripper_link3_M_end_effectors_galbot_gripper_link3_plastic_black" />
                                                       </body>
                                                     </body>
-                                                    <body name="left_gripper_tcp_link" pos="0.13996 0 0" quat="0.7071 0.7071 0 0" />
+                                                    <body name="left_gripper_tcp_link" pos="0.13996 0 0" quat="0.7071 -0.7071 0 0" />
                                                   </body>
                                                 </body>
                                               </body>
@@ -397,7 +397,7 @@
                                                         <geom type="mesh" class="visual" name="right_gripper_l_finger_link_visual_2" mesh="left_gripper_l_finger_link_link3_2" material="mtl_meshes_meshes_visual_end_effectors_galbot_gripper_link3_M_end_effectors_galbot_gripper_link3_plastic_black" />
                                                       </body>
                                                     </body>
-                                                    <body name="right_gripper_tcp_link" pos="0.13996 0 0" quat="0.7071 0.7071 0 0" />
+                                                    <body name="right_gripper_tcp_link" pos="0.13996 0 0" quat="0.7071 -0.7071 0 0" />
                                                   </body>
                                                 </body>
                                               </body>

--- a/scripts/validate_tcp_frames.py
+++ b/scripts/validate_tcp_frames.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Validate the Galbot gripper TCP transform across every published format."""
+
+from __future__ import annotations
+
+import math
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+TCP_NAMES = ("left_gripper_tcp_link", "right_gripper_tcp_link")
+EXPECTED_POS = (0.13996, 0.0, 0.0)
+EXPECTED_RPY = (-math.pi / 2.0, 0.0, 0.0)
+EXPECTED_QUAT_WXYZ = (math.sqrt(0.5), -math.sqrt(0.5), 0.0, 0.0)
+TOLERANCE = 1e-6
+
+
+def _values(raw: str, *, count: int, label: str) -> tuple[float, ...]:
+    values = tuple(float(value) for value in raw.split())
+    if len(values) != count:
+        raise ValueError(f"{label} must contain {count} values")
+    return values
+
+
+def _assert_close(
+    actual: tuple[float, ...], expected: tuple[float, ...], *, label: str
+) -> None:
+    if len(actual) != len(expected) or any(
+        not math.isclose(left, right, abs_tol=TOLERANCE)
+        for left, right in zip(actual, expected, strict=True)
+    ):
+        raise ValueError(f"{label}: expected {expected}, observed {actual}")
+
+
+def _assert_quat(actual: tuple[float, ...], *, label: str) -> None:
+    norm = math.sqrt(sum(value * value for value in actual))
+    if not math.isclose(norm, 1.0, abs_tol=1e-4):
+        raise ValueError(f"{label}: quaternion is not normalized: {actual}")
+    dot = sum(
+        left * right for left, right in zip(actual, EXPECTED_QUAT_WXYZ, strict=True)
+    )
+    if not math.isclose(abs(dot), 1.0, abs_tol=1e-4):
+        raise ValueError(
+            f"{label}: expected {EXPECTED_QUAT_WXYZ} up to sign, observed {actual}"
+        )
+
+
+def _validate_mjcf(path: Path) -> None:
+    root = ET.parse(path).getroot()
+    for name in TCP_NAMES:
+        matches = root.findall(f".//body[@name='{name}']")
+        if len(matches) != 1:
+            raise ValueError(f"{path}: expected one {name}, observed {len(matches)}")
+        body = matches[0]
+        _assert_close(
+            _values(body.attrib.get("pos", ""), count=3, label=f"{path}:{name} pos"),
+            EXPECTED_POS,
+            label=f"{path}:{name} pos",
+        )
+        _assert_quat(
+            _values(body.attrib.get("quat", ""), count=4, label=f"{path}:{name} quat"),
+            label=f"{path}:{name} quat",
+        )
+
+
+def _validate_urdf(path: Path) -> None:
+    root = ET.parse(path).getroot()
+    for name in TCP_NAMES:
+        matches = [
+            joint
+            for joint in root.findall("joint")
+            if (child := joint.find("child")) is not None
+            and child.attrib.get("link") == name
+        ]
+        if len(matches) != 1:
+            raise ValueError(
+                f"{path}: expected one joint for {name}, observed {len(matches)}"
+            )
+        origin = matches[0].find("origin")
+        if origin is None:
+            raise ValueError(f"{path}:{name} has no origin")
+        _assert_close(
+            _values(origin.attrib.get("xyz", ""), count=3, label=f"{path}:{name} xyz"),
+            EXPECTED_POS,
+            label=f"{path}:{name} xyz",
+        )
+        _assert_close(
+            _values(origin.attrib.get("rpy", ""), count=3, label=f"{path}:{name} rpy"),
+            EXPECTED_RPY,
+            label=f"{path}:{name} rpy",
+        )
+
+
+def _validate_xacro(path: Path) -> None:
+    root = ET.parse(path).getroot()
+    matches = [
+        joint
+        for joint in root.iter("joint")
+        if joint.attrib.get("name") == "${prefix}gripper_tcp_joint"
+    ]
+    if len(matches) != 1:
+        raise ValueError(
+            f"{path}: expected one gripper TCP joint, observed {len(matches)}"
+        )
+    origin = matches[0].find("origin")
+    if origin is None:
+        raise ValueError(f"{path}: gripper TCP joint has no origin")
+    _assert_close(
+        _values(origin.attrib.get("xyz", ""), count=3, label=f"{path}:TCP xyz"),
+        EXPECTED_POS,
+        label=f"{path}:TCP xyz",
+    )
+    _assert_close(
+        _values(origin.attrib.get("rpy", ""), count=3, label=f"{path}:TCP rpy"),
+        EXPECTED_RPY,
+        label=f"{path}:TCP rpy",
+    )
+
+
+def _usd_block(text: str, name: str, *, path: Path) -> str:
+    match = re.search(
+        rf'def Xform "{re.escape(name)}"\s*\{{(?P<body>.*?)\n\s*\}}', text, re.S
+    )
+    if match is None:
+        raise ValueError(f"{path}: cannot find USD Xform {name}")
+    return match.group("body")
+
+
+def _validate_usd(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    for name in TCP_NAMES:
+        block = _usd_block(text, name, path=path)
+        orient = re.search(r"xformOp:orient\s*=\s*\(([^)]+)\)", block)
+        translate = re.search(r"xformOp:translate\s*=\s*\(([^)]+)\)", block)
+        if orient is None or translate is None:
+            raise ValueError(f"{path}:{name} lacks an authored orient or translate")
+        _assert_quat(
+            _values(
+                orient.group(1).replace(",", " "),
+                count=4,
+                label=f"{path}:{name} orient",
+            ),
+            label=f"{path}:{name} orient",
+        )
+        _assert_close(
+            _values(
+                translate.group(1).replace(",", " "),
+                count=3,
+                label=f"{path}:{name} translate",
+            ),
+            EXPECTED_POS,
+            label=f"{path}:{name} translate",
+        )
+
+
+def main() -> int:
+    try:
+        _validate_xacro(ROOT / "xacro/components/galbot_gripper.xacro")
+        for path in (
+            ROOT / "urdf/galbot_one_golf.urdf",
+            ROOT / "urdf/galbot_one_golf_fixed_base.urdf",
+        ):
+            _validate_urdf(path)
+        for path in (
+            ROOT / "mjcf/galbot_one_golf.xml",
+            ROOT / "mjcf/galbot_one_golf_fixed_base.xml",
+            ROOT / "mjcf/galbot_one_golf_planar_base.xml",
+        ):
+            _validate_mjcf(path)
+        _validate_usd(ROOT / "usd/payloads/base.usda")
+    except (ET.ParseError, OSError, ValueError) as error:
+        print(f"TCP frame validation failed: {error}", file=sys.stderr)
+        return 1
+    print("TCP frames agree across Xacro, URDF, MJCF, and USD.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/urdf/galbot_one_golf.urdf
+++ b/urdf/galbot_one_golf.urdf
@@ -1902,7 +1902,7 @@
   <joint name="right_gripper_tcp_joint" type="fixed">
     <parent link="right_gripper_base_link"/>
     <child link="right_gripper_tcp_link"/>
-    <origin rpy="1.5707963267948966 0 0" xyz="0.13996 0 0"/>
+    <origin rpy="-1.5707963267948966 0 0" xyz="0.13996 0 0"/>
   </joint>
   <joint name="left_arm_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -2573,6 +2573,6 @@
   <joint name="left_gripper_tcp_joint" type="fixed">
     <parent link="left_gripper_base_link"/>
     <child link="left_gripper_tcp_link"/>
-    <origin rpy="1.5707963267948966 0 0" xyz="0.13996 0 0"/>
+    <origin rpy="-1.5707963267948966 0 0" xyz="0.13996 0 0"/>
   </joint>
 </robot>

--- a/urdf/galbot_one_golf_fixed_base.urdf
+++ b/urdf/galbot_one_golf_fixed_base.urdf
@@ -1294,7 +1294,7 @@
   <joint name="right_gripper_tcp_joint" type="fixed">
     <parent link="right_gripper_base_link"/>
     <child link="right_gripper_tcp_link"/>
-    <origin rpy="1.5707963267948966 0 0" xyz="0.13996 0 0"/>
+    <origin rpy="-1.5707963267948966 0 0" xyz="0.13996 0 0"/>
   </joint>
   <joint name="left_arm_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1965,6 +1965,6 @@
   <joint name="left_gripper_tcp_joint" type="fixed">
     <parent link="left_gripper_base_link"/>
     <child link="left_gripper_tcp_link"/>
-    <origin rpy="1.5707963267948966 0 0" xyz="0.13996 0 0"/>
+    <origin rpy="-1.5707963267948966 0 0" xyz="0.13996 0 0"/>
   </joint>
 </robot>

--- a/usd/payloads/base.usda
+++ b/usd/payloads/base.usda
@@ -873,7 +873,7 @@ def Xform "galbot_one_golf"
 
                     def Xform "left_gripper_tcp_link"
                     {
-                        quatd xformOp:orient = (0.7071067690849304, 0.7071067690849304, 0, 0)
+                        quatd xformOp:orient = (0.7071067690849304, -0.7071067690849304, 0, 0)
                         double3 xformOp:scale = (1, 1, 1)
                         double3 xformOp:translate = (0.13996000587940216, 0, 0)
                         uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
@@ -1906,7 +1906,7 @@ def Xform "galbot_one_golf"
 
                     def Xform "right_gripper_tcp_link"
                     {
-                        quatd xformOp:orient = (0.7071067690849304, 0.7071067690849304, 0, 0)
+                        quatd xformOp:orient = (0.7071067690849304, -0.7071067690849304, 0, 0)
                         double3 xformOp:scale = (1, 1, 1)
                         double3 xformOp:translate = (0.13996000587940216, 0, 0)
                         uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]

--- a/xacro/components/galbot_gripper.xacro
+++ b/xacro/components/galbot_gripper.xacro
@@ -382,7 +382,7 @@
 		<joint name="${prefix}gripper_tcp_joint" type="fixed">
 			<parent link="${prefix}gripper_base_link"/>
 			<child link="${prefix}gripper_tcp_link"/>
-			<origin rpy="1.5707963267948966 0 0" xyz="0.13996 0 0"/>
+			<origin rpy="-1.5707963267948966 0 0" xyz="0.13996 0 0"/>
 		</joint>
 
 	</xacro:macro>


### PR DESCRIPTION
## What

- restore both gripper TCP frames to the original Golf convention: translation
  `(0.13996, 0, 0)` and roll `-pi/2`
- keep Xacro, URDF, all MJCF variants, and USD consistent
- add a dependency-free cross-format validator and run it in GitHub Actions

## Why

The current descriptions authored the TCP with roll `+pi/2`, while the original
Golf assets and downstream motion-planning targets use `-pi/2`. That is an exact
180-degree X-axis frame error and can produce poor or infeasible IK/planning
results.

## Validation

- `python3 scripts/validate_tcp_frames.py`
- compiled all three MJCF variants with MuJoCo
- loaded the USD layer with OpenUSD and checked both TCP transforms and parents
- `ruff check` and `ruff format --check` for the validator

## Downstream impact

SynthNova and its Grocery, Yundonghui, and sim2real DLCs will pin this commit and
re-run their planner/calibration checks. Planner goals should remain expressed in
the original Golf TCP convention; no compensating 180-degree rotation should be
added downstream.
